### PR TITLE
Force IPv4 DNS resolution in SEA proxy server

### DIFF
--- a/grapher/sea/.gitignore
+++ b/grapher/sea/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+sea
+sea-prep.blob

--- a/grapher/sea/README.md
+++ b/grapher/sea/README.md
@@ -1,0 +1,30 @@
+# SEA proxy server
+
+Ce répertoire contient un petit serveur proxy Node.js qui ajoute des en-têtes CORS permissifs afin de contourner les restrictions de la SPA `5.html`.
+
+## Développement
+
+```bash
+npm install
+npm start
+```
+
+## Génération d'un exécutable autonome (SEA)
+
+Node.js ≥20 peut produire une application autonome (Single Executable Application). Le script suivant crée un binaire `sea` contenant ce serveur ainsi que le runtime Node.js :
+
+```bash
+npm run build
+```
+
+Cette commande effectue les étapes suivantes :
+
+1. génère un blob SEA à partir de `server.js` ;
+2. copie l'exécutable Node.js courant sous le nom `sea` ;
+3. injecte le blob dans ce binaire grâce à `postject`.
+
+Vous pouvez ensuite exécuter le serveur directement :
+
+```bash
+./sea
+```

--- a/grapher/sea/package.json
+++ b/grapher/sea/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "grapher-sea",
+  "version": "1.0.0",
+  "description": "Simple Node.js SEA proxy server to bypass CORS for grapher 5.html",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "build": "node --experimental-sea-config sea-config.json && cp $(command -v node) sea && npx postject sea NODE_SEA_BLOB sea-prep.blob --sentinel-fuse"
+  },
+  "devDependencies": {
+    "postject": "^1.0.0"
+  }
+}

--- a/grapher/sea/sea-config.json
+++ b/grapher/sea/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "./server.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true
+}

--- a/grapher/sea/server.js
+++ b/grapher/sea/server.js
@@ -1,0 +1,51 @@
+const dns = require("dns");
+dns.setDefaultResultOrder("ipv4first");
+
+const http = require('http');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+
+const server = http.createServer(async (req, res) => {
+  const reqUrl = new URL(req.url, `http://${req.headers.host}`);
+
+  // CORS headers
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (reqUrl.pathname === '/proxy') {
+    const target = reqUrl.searchParams.get('url');
+    if (!target) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Missing url parameter');
+      return;
+    }
+
+    let response;
+    try {
+      response = await fetch(target);
+    } catch (err) {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end(String(err));
+      return;
+    }
+
+    res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+    const data = Buffer.from(await response.arrayBuffer());
+    res.end(data);
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`SEA proxy server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- default Node.js DNS resolution to IPv4 for the SEA proxy

## Testing
- `node grapher/sea/server.js &`
- `curl -i "http://localhost:3000/proxy?url=https://example.com" | head -n 20` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ede80819883338dacd0a0e6a90563