### PR TITLE
fix: detect notch via safe-area insets

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -208,11 +208,9 @@ panel.classList.add('open');
 </script>
 <script>
 function detectNotchSide() {
-    const vv = window.visualViewport;
-    if (!vv) return;
-
-    const left = vv.offsetLeft;
-    const right = window.innerWidth - vv.width - vv.offsetLeft;
+    const style = getComputedStyle(document.documentElement);
+    const left = parseFloat(style.getPropertyValue('--safe-left')) || 0;
+    const right = parseFloat(style.getPropertyValue('--safe-right')) || 0;
 
     if (window.matchMedia("(orientation: landscape)").matches) {
         if (left > right) {
@@ -229,6 +227,8 @@ window.addEventListener("orientationchange", () => {
     // Attendre un peu que Safari mette à jour les safe-area-inset
     setTimeout(detectNotchSide, 200);
 });
+
+window.addEventListener("load", detectNotchSide);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- detect notch side using CSS safe-area insets
- run detection on load and orientation changes

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef5c6dbe88333bd4ba0348cc01963