### PR TITLE
Fix notch padding to respect safe area

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -12,7 +12,7 @@
 
   html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; background: #fff; }
 
-  #chartWrap { position: relative; width: 100vw; height: 100svh; min-height: 100svh; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); background: #fff; overflow: hidden; }
+  #chartWrap { position: relative; width: 100vw; height: 100svh; min-height: 100svh; padding-top: env(safe-area-inset-top); padding-bottom: env(safe-area-inset-bottom); background: #fff; overflow: hidden; box-sizing: border-box; }
   #chart { width: 100%; height: 100%; min-height: 320px; }
 
   #fab { position: fixed; right: calc(16px + env(safe-area-inset-right)); bottom: calc(16px + env(safe-area-inset-bottom)); width: var(--fab); height: var(--fab); border-radius: 50%; border: none; box-shadow: 0 4px 12px rgba(0,0,0,.24); background: #1976d2; color: #fff; font-size: 28px; line-height: 1; cursor: pointer; z-index: 1000; }
@@ -131,6 +131,7 @@ function applyNotchPadding() {
     chartWrap.style[prop] = inset + 'px';
     panel.style[prop] = inset + 'px';
   }
+  if (typeof chart !== 'undefined' && chart && chart.reflow) chart.reflow();
 }
 
 window.addEventListener('load', applyNotchPadding);


### PR DESCRIPTION
## Summary
- ensure chart container width includes safe-area padding by using border-box sizing
- trigger chart reflow after applying notch padding so axes stay visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689efe16aa308333bd6586673623f1bc