### PR TITLE
Align grouping label with date picker

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -202,15 +202,19 @@ function updateGroupingInfo(){
   const rs = chart.rangeSelector;
   if(rs){
     if(!rs.groupingLabel){
-      rs.groupingLabel = chart.renderer.text('',0,0).add(rs.group);
+      rs.groupingLabel = chart.renderer
+        .text('',0,0)
+        .css({ fontSize:'0.8em' })
+        .add(rs.group);
     }
-    rs.groupingLabel.attr({ text });
+    rs.groupingLabel.attr({ text: `(${text})` });
 
+    const spacing = 8;
     const lblBB = rs.groupingLabel.getBBox();
     const btnWidth = rs.buttonGroup ? rs.buttonGroup.getBBox().width : 0;
     let igBB = rs.inputGroup && rs.inputGroup.getBBox ? rs.inputGroup.getBBox() : {x:0,y:0,width:0,height:0};
-    const total = btnWidth + lblBB.width + igBB.width + 20;
-    const max = chart.chartWidth - 20;
+    const total = btnWidth + lblBB.width + igBB.width + spacing*3;
+    const max = chart.chartWidth - spacing;
     if(btnWidth && total > max){
       rs.buttonGroup.hide();
       rs.zoomText && rs.zoomText.hide();
@@ -220,15 +224,28 @@ function updateGroupingInfo(){
       rs.zoomText && rs.zoomText.show();
       igBB = rs.inputGroup && rs.inputGroup.getBBox ? rs.inputGroup.getBBox() : igBB;
     }
-    const x = Math.max(8, igBB.x - lblBB.width - 8);
-    const y = igBB.y + igBB.height/2 + lblBB.height/2;
-    rs.groupingLabel.attr({ x, y });
+    if(rs.inputGroup){
+      const rightEdge = chart.chartWidth - spacing;
+      const igX = rightEdge - (igBB.width + lblBB.width);
+      rs.inputGroup.translate(igX, igBB.y);
+      igBB = rs.inputGroup.getBBox();
+      const x = igBB.x + igBB.width + spacing/2;
+      const y = igBB.y + igBB.height/2 + lblBB.height/2;
+      rs.groupingLabel.attr({ x, y });
+    }
   }
 }
 
 chart = Highcharts.stockChart('chart', {
   chart: { spacingLeft: 8, spacingRight: 22, events:{ redraw: updateGroupingInfo } },
-  rangeSelector: { selected: 1, inputDateFormat: '%Y-%m-%d %H:%M', inputEditDateFormat: '%Y-%m-%d %H:%M', inputBoxWidth: 150 },
+  rangeSelector: {
+    selected: 1,
+    inputDateFormat: '%Y-%m-%d %H:%M',
+    inputEditDateFormat: '%Y-%m-%d %H:%M',
+    inputBoxWidth: 150,
+    buttonPosition: { align: 'left' },
+    inputPosition: { align: 'right' }
+  },
   xAxis: { events:{ afterSetExtremes: updateGroupingInfo } },
   title: { text: '' },
   credits: { enabled: false },


### PR DESCRIPTION
## Summary
- Show data grouping label to the right of the date picker with smaller text
- Align range selector inputs and grouping label to the chart right and zoom buttons to the left

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f0acaa0008333aab6d658646ece07