### PR TITLE
Revert post-0b7bee9 changes but keep aggregation badge

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -140,38 +140,20 @@ function applyNotchPadding() {
   if (typeof chart !== 'undefined' && chart && chart.reflow) chart.reflow();
 }
 
-function positionAggBadge(){
-  const badge = document.getElementById('aggBadge');
-  const chartWrap = document.getElementById('chartWrap');
-  if(!badge || !chart || !chart.container || !chartWrap) return;
-  const inputs = chart.container.querySelectorAll('input.highcharts-range-input');
-  if(!inputs.length) return;
-  const last = inputs[inputs.length-1];
-  const rect = last.getBoundingClientRect();
-  const wrapRect = chartWrap.getBoundingClientRect();
-  const top = rect.top - wrapRect.top + (rect.height - badge.offsetHeight)/2;
-  const left = rect.right - wrapRect.left + 8;
-  badge.style.top = top + 'px';
-  badge.style.left = left + 'px';
-}
-
 function adjustLayoutForOrientation(){
   if (typeof chart === 'undefined' || !chart) return;
   const chartWrap = document.getElementById('chartWrap');
   const isLandscape = window.matchMedia('(orientation: landscape)').matches;
   const baseNav = 40;
   const navH = isLandscape ? Math.round(baseNav * 0.7) : baseNav;
-  const navMargin = isLandscape ? 2 : 10;
-  chart.update({ navigator: { height: navH, margin: navMargin }, chart:{ spacingBottom: navMargin } }, false);
+  chart.update({ navigator: { height: navH } }, false);
   chart.redraw();
   if (isLandscape){
     chartWrap.style.height = '100svh';
   } else {
-    const mainH = Math.round(window.innerHeight * 0.3);
-    chartWrap.style.height = (mainH + navH) + 'px';
+    chartWrap.style.height = Math.round(window.innerHeight / 3) + 'px';
   }
   chart.reflow();
-  positionAggBadge();
 }
 
 window.addEventListener('load', () => { applyNotchPadding(); adjustLayoutForOrientation(); });
@@ -238,13 +220,11 @@ function updateGroupingInfo(){
     if(info) info.textContent = 'Current grouping: none';
     if(badge){ badge.textContent=''; badge.style.display='none'; }
   }
-  positionAggBadge();
 }
 
 chart = Highcharts.stockChart('chart', {
   chart: { spacingLeft: 8, spacingRight: 22, events:{ redraw: updateGroupingInfo } },
-  rangeSelector: { buttons: [], selected: 0, inputDateFormat: '%Y-%m-%d %H:%M', inputEditDateFormat: '%Y-%m-%d %H:%M', inputBoxWidth: 150, labelStyle:{display:'none'} },
-  navigation: { buttonOptions: { enabled: false } },
+  rangeSelector: { selected: 1, inputDateFormat: '%Y-%m-%d %H:%M', inputEditDateFormat: '%Y-%m-%d %H:%M', inputBoxWidth: 150 },
   xAxis: { events:{ afterSetExtremes: updateGroupingInfo } },
   title: { text: '' },
   credits: { enabled: false },


### PR DESCRIPTION
## Summary
- Revert grapher/5.html to its state at commit 0b7bee9 to undo subsequent layout and navigation tweaks
- Preserve the aggregation step badge so the current data grouping remains visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f33bceb588333afc58adcf76d0319