### PR TITLE
feat(ui): improve mobile controls and chart display

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -27,13 +27,16 @@
   textarea, input[type="text"], select { width: 100%; padding: 8px; box-sizing: border-box; max-width: 100%; }
   textarea { min-height: 140px; resize: vertical; }
   .actions { display: flex; flex-wrap: wrap; gap: 8px; }
-  button { padding: 8px 12px; cursor: pointer; }
+  .actions button { flex:1 1 auto; }
+  button:not(#fab) { appearance:none; border:none; padding:10px 16px; border-radius:10px; background:#007aff; color:#fff; font-size:16px; cursor:pointer; }
+  button.destructive { background:#ff3b30; }
+  button.secondary { background:#fff; color:#007aff; border:1px solid #007aff; }
   .muted { color: #666; }
   .section-title { margin: 0; padding: 10px; position: sticky; top: 0; background: #fafafa; }
 
   table { width: 100%; border-collapse: collapse; table-layout: fixed; }
   th, td { text-align: left; padding: 8px; border-bottom: 1px solid #eee; }
-  th { background: #fafafa; position: sticky; top: 42px; z-index: 1; }
+  th { background: #fafafa; }
   td input, td select { width: 100%; box-sizing: border-box; }
 
   .dropzone { margin: 10px; border: 2px dashed #bbb; border-radius: 10px; padding: 28px; text-align: center; cursor: pointer; transition: border-color .15s ease, background .15s ease; background: #fafafa; }
@@ -57,7 +60,7 @@
         <button id="btnExportAll" type="button">Export all</button>
         <button id="btnImportAll" type="button">Import</button>
         <button id="btnLoadAllSaved" type="button">Load all</button>
-        <button id="btnClearAll" type="button">Delete all</button>
+        <button id="btnClearAll" class="destructive" type="button">Delete all</button>
         <input id="importAllInput" type="file" accept=".json" style="display:none" />
       </div>
     </section>
@@ -184,6 +187,27 @@ function applyGlobalStacking(){ const any = userSeries().some(s=> (s.userOptions
 
 let chart;
 
+function updateAggBadge(){
+  let badge = document.getElementById('aggBadge');
+  if(!badge){
+    badge = document.createElement('div');
+    badge.id = 'aggBadge';
+    badge.style.cssText = 'position:absolute;top:8px;right:8px;background:#007aff;color:#fff;padding:2px 6px;border-radius:12px;font-size:12px;line-height:1;z-index:10;pointer-events:none;';
+    document.getElementById('chartWrap').appendChild(badge);
+  }
+  const s = chart.series && chart.series.find? chart.series.find(x=>x.name !== 'Navigator 1') : null;
+  const g = s && s.currentDataGrouping;
+  if(g){
+    const unitMap = { millisecond:'ms', second:'s', minute:'m', hour:'h', day:'d', week:'w', month:'M', year:'y' };
+    const count = g.count || 1;
+    const unit = unitMap[g.unitName] || g.unitName;
+    badge.textContent = `${count}${unit}`;
+    badge.style.display = 'block';
+  } else {
+    badge.style.display = 'none';
+  }
+}
+
 function updateGroupingInfo(){
   const info = document.getElementById('groupingInfo');
   if(!info || !chart) return;
@@ -195,6 +219,7 @@ function updateGroupingInfo(){
   } else {
     info.textContent = 'Current grouping: none';
   }
+  updateAggBadge();
 }
 
 chart = Highcharts.stockChart('chart', {
@@ -211,6 +236,16 @@ chart = Highcharts.stockChart('chart', {
 });
 updateGroupingInfo();
 const userSeries = () => chart.series.filter(s => s.name !== 'Navigator 1');
+
+const baseNavHeight = chart.options.navigator && chart.options.navigator.height || 40;
+function adjustNavigatorHeight(){
+  const isLandscape = window.innerWidth > window.innerHeight;
+  const h = isLandscape ? baseNavHeight * 0.7 : baseNavHeight;
+  chart.update({ navigator:{ height: h } }, false);
+  chart.redraw();
+}
+window.addEventListener('resize', adjustNavigatorHeight);
+adjustNavigatorHeight();
 
 function addSeriesToChart(name, data, uiType, agg='auto'){ const { actualType } = normalizeType(uiType); const yIdx = yAxisIndexForType(uiType||'spline'); const s = chart.addSeries({ name, data, type: actualType, yAxis: yIdx }, false); s.update({ _uiType: (uiType||'spline') }, false); setSeriesAggregation(s, agg || 'auto'); return s; }
 function replaceChartWithSeries(seriesList){ while(chart.series.length) chart.series[0].remove(false); for(const s of seriesList) addSeriesToChart(s.name, s.data, s.type, s.agg||'auto'); applyGlobalStacking(); chart.redraw(); buildSeriesTable(); updatePrimaryArea(); }
@@ -249,10 +284,10 @@ function updatePrimaryArea(){ const primary = document.getElementById('primaryAr
     `; const fileInput = document.getElementById('fileInput'); dz.addEventListener('click', ()=> fileInput.click()); dz.addEventListener('dragover', (e)=>{ e.preventDefault(); dz.classList.add('dragover'); }); dz.addEventListener('dragleave', ()=> dz.classList.remove('dragover')); dz.addEventListener('drop', (e)=>{ e.preventDefault(); dz.classList.remove('dragover'); const f = e.dataTransfer.files && e.dataTransfer.files[0]; if(!f) return; handleFileImport(f, {alsoLoad:true, showAlert:true}); }); dz.querySelector('#manualUploadLink').addEventListener('click', (e)=>{ e.preventDefault(); fileInput.click(); }); primary.appendChild(dz); } else { const title = document.createElement('h3'); title.className = 'section-title'; title.textContent = 'Series'; primary.appendChild(title); const wrap = document.createElement('div'); wrap.id = 'seriesTableWrap'; primary.appendChild(wrap); buildSeriesTable(); } }
 
 /* ====== Series table ====== */
-function buildSeriesTable(){ const wrap = document.getElementById('seriesTableWrap') || document.getElementById('primaryArea'); const list = userSeries(); if(!list.length){ wrap.innerHTML = '<div class="muted">No series on chart.</div>'; return; } const tbl = document.createElement('table'); const thead = document.createElement('thead'); thead.innerHTML = `<tr><th>Name</th><th>Type</th><th>Aggregation</th><th></th></tr>`; const tbody = document.createElement('tbody'); list.forEach((s)=>{ const tr = document.createElement('tr'); const tdName = document.createElement('td'); const nameInput = document.createElement('input'); nameInput.type='text'; nameInput.value=s.name; nameInput.addEventListener('change', ()=>{ s.update({ name: nameInput.value }, false); chart.redraw(); saveActiveFromChart(); }); tdName.appendChild(nameInput); const tdType = document.createElement('td'); const selType = document.createElement('select'); TYPE_OPTIONS.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; selType.appendChild(o); }); const uiType = s.userOptions && s.userOptions._uiType ? s.userOptions._uiType : (s.type==='column' && chart.options.plotOptions?.column?.stacking) ? 'column-stacked' : s.type; selType.value = uiType; selType.addEventListener('change', ()=>{ const chosen = selType.value; const { actualType } = normalizeType(chosen); const yAxisIdx = yAxisIndexForType(chosen); s.update({ type: actualType, yAxis: yAxisIdx, _uiType: chosen }, false); applyGlobalStacking(); chart.redraw(); saveActiveFromChart(); }); tdType.appendChild(selType); const tdAgg = document.createElement('td'); const selAgg = document.createElement('select'); AGG_OPTIONS.forEach(a=>{ const o=document.createElement('option'); o.value=a; o.textContent=a; selAgg.appendChild(o); }); selAgg.value = (s.userOptions && s.userOptions._agg) ? s.userOptions._agg : 'auto'; selAgg.addEventListener('change', ()=>{ setSeriesAggregation(s, selAgg.value); chart.redraw(); saveActiveFromChart(); }); tdAgg.appendChild(selAgg); const tdAct = document.createElement('td'); const btnRemove = document.createElement('button'); btnRemove.textContent='Remove'; btnRemove.addEventListener('click', ()=>{ s.remove(false); applyGlobalStacking(); chart.redraw(); buildSeriesTable(); saveActiveFromChart(); updatePrimaryArea(); }); tdAct.appendChild(btnRemove); tr.append(tdName, tdType, tdAgg, tdAct); tbody.appendChild(tr); }); tbl.append(thead, tbody); wrap.innerHTML = ''; wrap.appendChild(tbl); }
+function buildSeriesTable(){ const wrap = document.getElementById('seriesTableWrap') || document.getElementById('primaryArea'); const list = userSeries(); if(!list.length){ wrap.innerHTML = '<div class="muted">No series on chart.</div>'; return; } const tbl = document.createElement('table'); const thead = document.createElement('thead'); thead.innerHTML = `<tr><th>Name</th><th>Type</th><th>Aggregation</th><th></th></tr>`; const tbody = document.createElement('tbody'); list.forEach((s)=>{ const tr = document.createElement('tr'); const tdName = document.createElement('td'); const nameInput = document.createElement('input'); nameInput.type='text'; nameInput.value=s.name; nameInput.addEventListener('change', ()=>{ s.update({ name: nameInput.value }, false); chart.redraw(); saveActiveFromChart(); }); tdName.appendChild(nameInput); const tdType = document.createElement('td'); const selType = document.createElement('select'); TYPE_OPTIONS.forEach(t=>{ const o=document.createElement('option'); o.value=t; o.textContent=t; selType.appendChild(o); }); const uiType = s.userOptions && s.userOptions._uiType ? s.userOptions._uiType : (s.type==='column' && chart.options.plotOptions?.column?.stacking) ? 'column-stacked' : s.type; selType.value = uiType; selType.addEventListener('change', ()=>{ const chosen = selType.value; const { actualType } = normalizeType(chosen); const yAxisIdx = yAxisIndexForType(chosen); s.update({ type: actualType, yAxis: yAxisIdx, _uiType: chosen }, false); applyGlobalStacking(); chart.redraw(); saveActiveFromChart(); }); tdType.appendChild(selType); const tdAgg = document.createElement('td'); const selAgg = document.createElement('select'); AGG_OPTIONS.forEach(a=>{ const o=document.createElement('option'); o.value=a; o.textContent=a; selAgg.appendChild(o); }); selAgg.value = (s.userOptions && s.userOptions._agg) ? s.userOptions._agg : 'auto'; selAgg.addEventListener('change', ()=>{ setSeriesAggregation(s, selAgg.value); chart.redraw(); saveActiveFromChart(); }); tdAgg.appendChild(selAgg); const tdAct = document.createElement('td'); const iconRemove = document.createElement('span'); iconRemove.textContent='🗑️'; iconRemove.style.cursor='pointer'; iconRemove.addEventListener('click', ()=>{ s.remove(false); applyGlobalStacking(); chart.redraw(); buildSeriesTable(); saveActiveFromChart(); updatePrimaryArea(); }); tdAct.appendChild(iconRemove); tr.append(tdName, tdType, tdAgg, tdAct); tbody.appendChild(tr); }); tbl.append(thead, tbody); wrap.innerHTML = ''; wrap.appendChild(tbl); }
 
 /* ====== Saved datasets UI ====== */
-function renderSavedList(){ const container = document.getElementById('savedList'); const metas = getAllMetas(); if(!metas.length){ container.textContent='No saved datasets yet.'; return; } const active = lsGet(ACTIVE_KEY); const frag = document.createDocumentFragment(); metas.forEach(m=>{ const div=document.createElement('div'); const strong = document.createElement('strong'); strong.textContent = m.name; const span1 = document.createElement('span'); span1.className='muted'; span1.textContent = ` (${m.count} series)`; div.appendChild(strong); div.appendChild(document.createTextNode(' ')); div.appendChild(span1); if(m.id===active){ const activeSpan=document.createElement('span'); activeSpan.className='muted'; activeSpan.textContent=' • active'; div.appendChild(document.createTextNode(' ')); div.appendChild(activeSpan); } const row=document.createElement('div'); row.className='actions'; const btnLoad=document.createElement('button'); btnLoad.textContent='Load'; btnLoad.addEventListener('click', ()=>{ const ds=getDataset(m.id); if(!ds) return; (ds.series||[]).forEach(sdef=>addSeriesToChart(sdef.name, sdef.data, sdef.type||'spline', sdef.agg||'auto')); applyGlobalStacking(); chart.redraw(); lsSet(ACTIVE_KEY, m.id); saveActiveFromChart(); updatePrimaryArea(); }); const btnDel=document.createElement('button'); btnDel.textContent='Delete'; btnDel.addEventListener('click', ()=>{ if(confirm(`Delete "${m.name}"?`)) { deleteDataset(m.id); renderSavedList(); } }); row.append(btnLoad, btnDel); div.appendChild(row); frag.appendChild(div); }); container.innerHTML=''; container.appendChild(frag); }
+function renderSavedList(){ const container = document.getElementById('savedList'); const metas = getAllMetas(); if(!metas.length){ container.textContent='No saved datasets yet.'; return; } const active = lsGet(ACTIVE_KEY); const frag = document.createDocumentFragment(); metas.forEach(m=>{ const div=document.createElement('div'); const strong = document.createElement('strong'); strong.textContent = m.name; const span1 = document.createElement('span'); span1.className='muted'; span1.textContent = ` (${m.count} series)`; div.appendChild(strong); div.appendChild(document.createTextNode(' ')); div.appendChild(span1); if(m.id===active){ const activeSpan=document.createElement('span'); activeSpan.className='muted'; activeSpan.textContent=' • active'; div.appendChild(document.createTextNode(' ')); div.appendChild(activeSpan); } const row=document.createElement('div'); row.className='actions'; const btnLoad=document.createElement('button'); btnLoad.textContent='Load'; btnLoad.addEventListener('click', ()=>{ const ds=getDataset(m.id); if(!ds) return; (ds.series||[]).forEach(sdef=>addSeriesToChart(sdef.name, sdef.data, sdef.type||'spline', sdef.agg||'auto')); applyGlobalStacking(); chart.redraw(); lsSet(ACTIVE_KEY, m.id); saveActiveFromChart(); updatePrimaryArea(); }); const btnDel=document.createElement('button'); btnDel.className='destructive'; btnDel.textContent='Delete'; btnDel.addEventListener('click', ()=>{ if(confirm(`Delete "${m.name}"?`)) { deleteDataset(m.id); renderSavedList(); } }); row.append(btnLoad, btnDel); div.appendChild(row); frag.appendChild(div); }); container.innerHTML=''; container.appendChild(frag); }
 
 /* ====== Import/Export/Clear ====== */
 document.getElementById('btnExportAll').addEventListener('click', ()=>{ const ids=listIds(); const out={}; ids.forEach(id=>{ const ds=getDataset(id); if(ds) out[id]=ds; }); const blob = new Blob([JSON.stringify(out, null, 2)], { type:'application/json' }); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='time_series_datasets.json'; a.click(); URL.revokeObjectURL(a.href); });


### PR DESCRIPTION
## Summary
- style buttons with iOS-like appearance for better mobile use
- replace series removal button with trash icon and drop sticky table header
- show current aggregation badge on chart and shrink navigator in landscape

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5512ca0483339eac2e982ec52407