### PR TITLE
Réduire la largeur du date picker du chart

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -224,7 +224,13 @@ function updateGroupingInfo(){
 
 chart = Highcharts.stockChart('chart', {
   chart: { spacingLeft: 8, spacingRight: 22, events:{ redraw: updateGroupingInfo } },
-  rangeSelector: { selected: 1, inputDateFormat: '%Y-%m-%d %H:%M', inputEditDateFormat: '%Y-%m-%d %H:%M', inputBoxWidth: 150 },
+  rangeSelector: {
+    selected: 1,
+    inputDateFormat: '%Y-%m-%d %H:%M',
+    inputEditDateFormat: '%Y-%m-%d %H:%M',
+    inputBoxWidth: 110,
+    labelStyle: { display: 'none' }
+  },
   xAxis: { events:{ afterSetExtremes: updateGroupingInfo } },
   title: { text: '' },
   credits: { enabled: false },


### PR DESCRIPTION
## Summary
- Réduit la largeur du date picker du range selector et masque les étiquettes pour économiser l'espace horizontal

## Testing
- `npm test` *(échoué: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02d0fb2408333afb3ac71dde859d2