### PR TITLE
Refactor bottom sheet controls

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -16,19 +16,13 @@
       font-family:-apple-system,BlinkMacSystemFont,'Helvetica Neue',Helvetica,Arial,sans-serif;
       background:var(--bg); color:#000; overflow:hidden;
     }
-    #topbar {
-      position:fixed; top:0; left:0; right:0; height:44px;
-      padding-top:env(safe-area-inset-top); padding-left:env(safe-area-inset-left); padding-right:env(safe-area-inset-right);
-      display:flex; align-items:center; justify-content:space-between;
-      background:rgba(255,255,255,.9); backdrop-filter:blur(20px);
-      box-shadow:0 1px 0 rgba(0,0,0,.1); z-index:1000;
-    }
-    #topbar h1 { font-size:17px; font-weight:600; margin:0 auto; }
     #settingsBtn {
-      width:44px; height:44px; appearance:none; border:none; background:none; font-size:24px; color:var(--blue); cursor:pointer;
+      position:fixed; bottom:24px; right:24px; width:56px; height:56px; appearance:none; border:none; border-radius:50%; padding:0;
+      display:flex; align-items:center; justify-content:center; background:var(--blue); color:#fff; font-size:28px; cursor:pointer;
+      box-shadow:0 4px 12px rgba(0,0,0,.2); z-index:1100;
     }
-    #chartWrap { position:absolute; top:44px; left:0; right:0; bottom:0; transition:transform .3s ease, filter .3s ease; }
-    #chartWrap.pushed { transform:scale(.95); filter:blur(2px); }
+    #chartWrap { position:absolute; top:0; left:0; right:0; bottom:0; transition:transform .3s ease; }
+    #chartWrap.pushed { transform:scale(.95); }
     #chart { width:100%; height:100%; }
     #panel {
       position:fixed; left:0; right:0; bottom:0; max-height:70%;
@@ -41,7 +35,7 @@
     #panel.open { transform:translateY(0); }
     #grabber { width:40px; height:5px; background:#c7c7cc; border-radius:2.5px; margin:8px auto; flex:0 0 auto; }
     #panelContent { flex:1 1 auto; overflow-y:auto; -webkit-overflow-scrolling:touch; }
-    .section { padding:0 16px 16px; }
+    .section { padding:0 16px 16px; position:sticky; top:0; background:inherit; z-index:1; }
     h3.section-title { margin:0; padding:10px 0; font-size:17px; font-weight:600; }
     textarea, input[type="text"], select { width:100%; padding:8px; box-sizing:border-box; }
     textarea { min-height:140px; resize:vertical; }
@@ -59,11 +53,8 @@
   </style>
 </head>
 <body>
-  <header id="topbar">
-    <h1>Stocks</h1>
-    <button id="settingsBtn" aria-controls="panel" aria-expanded="false">☰</button>
-  </header>
   <div id="chartWrap"><div id="chart"></div></div>
+  <button id="settingsBtn" aria-controls="panel" aria-expanded="false">⚙️</button>
   <aside id="panel" aria-label="Controls" tabindex="-1">
     <div id="grabber"></div>
     <div id="panelContent">
@@ -363,6 +354,7 @@
     const panel = $('panel');
     const settingsBtn = $('settingsBtn');
     const chartWrapEl = $('chartWrap');
+    const grabber = $('grabber');
     const togglePanel = () => {
       const willOpen=!panel.classList.contains('open');
       panel.classList.toggle('open');
@@ -371,12 +363,12 @@
       if(willOpen) panel.focus();
     };
     settingsBtn.addEventListener('click', togglePanel);
-    $('grabber').addEventListener('click', togglePanel);
+    grabber.addEventListener('click', togglePanel);
     window.addEventListener('keydown', e=>{ if(e.key==='Escape' && panel.classList.contains('open')) togglePanel(); });
-    let startY=null;
-    panel.addEventListener('touchstart', e=>{ if(!panel.classList.contains('open')) return; startY=e.touches[0].clientY; });
-    panel.addEventListener('touchmove', e=>{ if(startY===null) return; const dy=e.touches[0].clientY-startY; if(dy>0) panel.style.transform=`translateY(${dy}px)`; });
-    panel.addEventListener('touchend', e=>{ if(startY===null) return; const dy=e.changedTouches[0].clientY-startY; panel.style.transform=''; if(dy>100) togglePanel(); startY=null; });
+    let startY=null, dragging=false;
+    grabber.addEventListener('touchstart', e=>{ if(!panel.classList.contains('open')) return; startY=e.touches[0].clientY; dragging=true; });
+    window.addEventListener('touchmove', e=>{ if(!dragging) return; const dy=e.touches[0].clientY-startY; if(dy>0) panel.style.transform=`translateY(${dy}px)`; });
+    window.addEventListener('touchend', e=>{ if(!dragging) return; const dy=e.changedTouches[0].clientY-startY; panel.style.transform=''; if(dy>100) togglePanel(); dragging=false; startY=null; });
 
     renderSavedList();
     updatePrimaryArea();


### PR DESCRIPTION
## Summary
- Replace top bar with floating settings button and make chart full-screen
- Remove blur from chart when sheet open while preserving scale effect
- Restrict sheet drag-to-close to its grab handle and keep sheet sections sticky

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03bea365483339db3a9b242211405