### PR TITLE
Fix Y-axis placement and update FAB icon

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -54,7 +54,7 @@
 </head>
 <body>
   <div id="chartWrap"><div id="chart"></div></div>
-  <button id="settingsBtn" aria-controls="panel" aria-expanded="false">⚙️</button>
+  <button id="settingsBtn" aria-controls="panel" aria-expanded="false">&#9776;</button>
   <aside id="panel" aria-label="Controls" tabindex="-1">
     <div id="grabber"></div>
     <div id="panelContent">
@@ -175,7 +175,7 @@
       tooltip: { shared:true, split:false },
       series: [],
       legend:{ enabled:true, align:'center', verticalAlign:'bottom' },
-      yAxis:[{ lineWidth:1 }, { lineWidth:1, opposite:true }]
+      yAxis:[{ lineWidth:1, opposite:false }, { lineWidth:1, opposite:true }]
     });
 
     const userSeries = () => chart.series.filter(s=>!s.options.isInternal);


### PR DESCRIPTION
## Summary
- Ensure column and stacked column series use left Y-axis and others use right axis
- Replace settings FAB gear icon with monochrome hamburger icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a043a8e34483338cd161e3542fbb74