### PR TITLE
Hide y-axis lines while keeping labels

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -175,7 +175,10 @@
       tooltip: { shared:true, split:false },
       series: [],
       legend:{ enabled:true, align:'center', verticalAlign:'bottom' },
-      yAxis:[{ lineWidth:1, opposite:false }, { lineWidth:1, opposite:true, labels:{ align:'left', x:4 } }]
+      yAxis:[
+        { lineWidth:0, tickWidth:0, opposite:false, labels:{ enabled:true } },
+        { lineWidth:0, tickWidth:0, opposite:true, labels:{ align:'left', x:4, enabled:true } }
+      ]
     });
 
     const userSeries = () => chart.series.filter(s=>!s.options.isInternal);


### PR DESCRIPTION
## Summary
- Remove y-axis lines and tick marks but keep label values visible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a047aa21fc8333ae4239517b49038d