### PR TITLE
Adjust navigator height in landscape

### DIFF
--- a/grapher/5.html
+++ b/grapher/5.html
@@ -246,7 +246,8 @@ const userSeries = () => chart.series.filter(s => s.name !== 'Navigator 1');
 const baseNavHeight = chart.options.navigator && chart.options.navigator.height || 40;
 function adjustNavigatorHeight(){
   const isLandscape = window.innerWidth > window.innerHeight;
-  const h = isLandscape ? baseNavHeight * 0.7 : baseNavHeight;
+  // In landscape, shrink the navigator so the main chart gains vertical space
+  const h = isLandscape ? baseNavHeight * 0.5 : baseNavHeight;
   chart.update({ navigator:{ height: h } }, false);
   chart.redraw();
 }


### PR DESCRIPTION
## Summary
- Shrink Highcharts navigator when in landscape orientation so main chart occupies more height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04fb84df483338df6065331a18d1a