### PR TITLE
Improve chart sizing in landscape

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -182,6 +182,18 @@
     });
 
     const userSeries = () => chart.series.filter(s=>!s.options.isInternal);
+
+    const baseNavHeight = chart.options.navigator && chart.options.navigator.height || 40;
+    function adjustNavigatorHeight(){
+      const isLandscape = window.innerWidth > window.innerHeight;
+      // In landscape, shrink the navigator so the main chart gains vertical space
+      const h = isLandscape ? baseNavHeight * 0.5 : baseNavHeight;
+      chart.update({ navigator:{ height: h } }, false);
+      chart.redraw();
+    }
+    window.addEventListener('resize', adjustNavigatorHeight);
+    adjustNavigatorHeight();
+
     const yAxisIndexForType = t => (t==='column' || t==='column-stacked') ? 0 : 1;
     const normalizeType = t => t==='column-stacked'?{ actualType:'column', stacked:true }:{ actualType:(t||'spline'), stacked:false };
     function applyGlobalStacking(){


### PR DESCRIPTION
## Summary
- Shrink navigator in 6.html to give main chart more vertical space on landscape screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0515cb0208333bb267ff1b1af27be