### PR TITLE
Display time in chart range selector

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -169,7 +169,12 @@
     const chart = Highcharts.stockChart('chart', {
       chart:{ events:{ redraw: updateGroupingInfo } },
       xAxis:{ events:{ afterSetExtremes: updateGroupingInfo } },
-      rangeSelector: { selected:1 },
+      rangeSelector: {
+        selected:1,
+        inputDateFormat:'%Y-%m-%d %H:%M',
+        inputEditDateFormat:'%Y-%m-%d %H:%M',
+        inputBoxWidth:150
+      },
       title: { text: '' },
       credits: { enabled:false },
       tooltip: { shared:true, split:false },


### PR DESCRIPTION
## Summary
- Show hours and minutes in Highcharts range selector by specifying date and edit formats
- Broaden range selector input width for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0734c12e883338aac0b5718e1ded8