### PR TITLE
Enable full-screen mode for iOS home screen

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>TS Viewer</title>
   <script src="https://code.highcharts.com/stock/highstock.js"></script>
   <style>


### PR DESCRIPTION
## Summary
- allow `grapher/6.html` to open in standalone mode when added to an iOS home screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a002bbe48333b50ccb95504daa6a