### PR TITLE
Center settings panel in landscape mode

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -37,6 +37,15 @@
       display:flex; flex-direction:column; overflow:hidden; padding-bottom:env(safe-area-inset-bottom);
     }
     #panel.open { transform:translateY(0); }
+    @media (orientation: landscape) {
+      #panel {
+        width:70%;
+        left:50%;
+        right:auto;
+        transform:translate(-50%,100%);
+      }
+      #panel.open { transform:translate(-50%,0); }
+    }
     #grabber { width:40px; height:5px; background:#c7c7cc; border-radius:2.5px; margin:8px auto; flex:0 0 auto; }
     #panelContent { flex:1 1 auto; overflow-y:auto; -webkit-overflow-scrolling:touch; }
     .section { padding:0 16px 16px; }
@@ -432,7 +441,14 @@
       if(e.touches[0].clientY-rect.top>40) return;
       startY=e.touches[0].clientY; dragging=true;
     });
-    window.addEventListener('touchmove', e=>{ if(!dragging) return; const dy=e.touches[0].clientY-startY; if(dy>0) panel.style.transform=`translateY(${dy}px)`; });
+    window.addEventListener('touchmove', e=>{
+      if(!dragging) return;
+      const dy=e.touches[0].clientY-startY;
+      if(dy>0){
+        const isLandscape=window.matchMedia('(orientation: landscape)').matches;
+        panel.style.transform=isLandscape?`translate(-50%, ${dy}px)`:`translateY(${dy}px)`;
+      }
+    });
     window.addEventListener('touchend', e=>{ if(!dragging) return; const dy=e.changedTouches[0].clientY-startY; panel.style.transform=''; if(dy>100) togglePanel(); dragging=false; startY=null; });
 
     renderSavedList();


### PR DESCRIPTION
## Summary
- Limit settings panel width to 70% on landscape screens and center it.
- Preserve horizontal centering when dragging the panel.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes htmlhint grapher/6.html`


------
https://chatgpt.com/codex/tasks/task_e_68a0b89f770c83339c0506250eeadc2d