### PR TITLE
Toggle background color when panel opens

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -425,11 +425,13 @@
     const chartWrapEl = $('chartWrap');
     const grabber = $('grabber');
     const panelContent = $('panelContent');
+    const rootEl = document.documentElement;
     const togglePanel = () => {
       const willOpen=!panel.classList.contains('open');
       panel.classList.toggle('open');
       settingsBtn.setAttribute('aria-expanded', String(willOpen));
       chartWrapEl.classList.toggle('pushed', willOpen);
+      rootEl.style.setProperty('--bg', willOpen ? 'white' : 'black');
       if(willOpen) panel.focus();
     };
     settingsBtn.addEventListener('click', togglePanel);


### PR DESCRIPTION
## Summary
- Switch CSS `--bg` between black and white when the settings sheet opens or closes

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a185381d0c8333a5f2f04e8fc4773c