### PR TITLE
Open panel when time series loaded

### DIFF
--- a/grapher/6.html
+++ b/grapher/6.html
@@ -369,6 +369,7 @@
         wrap.id='seriesTableWrap';
         primary.appendChild(wrap);
         buildSeriesTable();
+        if(!panel.classList.contains('open')) togglePanel();
       }
     }
     function buildSeriesTable(){


### PR DESCRIPTION
## Summary
- Automatically open the control panel when series are present so users see series details after loading datasets.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e64a46348333b38a06675dccfaa2